### PR TITLE
fix: fail to sync when path2 different from path1

### DIFF
--- a/bin/rclone-sync.sh
+++ b/bin/rclone-sync.sh
@@ -264,6 +264,7 @@ rclone_path_cmp() {
     rclone_set_diff "$p1" "$p2" "$p1p2_diff"
     rclone_set_diff "$p2" "$p1" "$p2p1_diff"
     rclone_path_cmp_diff "$1" "$2"
+    rclone_path_cmp_diff "$2" "$1"
     rclone_path_cmp_inter "$1" "$2"
 }
 rclone_show_delta() {


### PR DESCRIPTION
Missing path_cmp_diff path2 path1 which will ignore the changes in
path2.

see issue #2 